### PR TITLE
#77: add user setting to open image to fit window or use last zoom setting.

### DIFF
--- a/web-app/locales/en/translation.json
+++ b/web-app/locales/en/translation.json
@@ -67,6 +67,7 @@
         "alt-path": "Alternative path values",
         "box-padding": "Box padding",
         "default-image-type": "Default Image Type",
+        "fit-image-to-window": "Open new image to fit window",
         "default-folder-path": "Default Folder",
         "dilation-count": "Filter Pass Count",
         "dpi-default-usage": "Default DPI Usage",

--- a/web-app/locales/en/translation.json
+++ b/web-app/locales/en/translation.json
@@ -3,12 +3,13 @@
 
     "titles": {
         "add-folder": "Add Folder",
+        "application-settings": "Application Settings",
         "default-region": "Region Defaults",
         "dpi": "DPI Settings",
         "duplicates-detected": "Resolve Existing Images",
         "jpeg": "JPEG Settings",
         "bounding-box": "Bounding Box Configuration",
-        "image-settings": "Image Settings",
+        "image-settings": "Image Output Settings",
         "image-processing": "Image Processing Settings",
         "image-editing": "Image Editing",
         "manage-folders": "Manage Folders",

--- a/web-app/src/resources/elements/image/image-canvas.js
+++ b/web-app/src/resources/elements/image/image-canvas.js
@@ -441,8 +441,6 @@ export class ImageCanvas {
             }
             img.src = newImage;
             this._image = img;
-
-            alert("DEV 002: scaling factor in paint image = " + this.scalingFactor);
         } else {
             let canvas = this._getCanvas();
             let ctx = this._getContext();

--- a/web-app/src/resources/elements/image/image-canvas.js
+++ b/web-app/src/resources/elements/image/image-canvas.js
@@ -436,6 +436,14 @@ export class ImageCanvas {
                 cvs.attr('width', this._toScaledSize(img.width));
                 cvs.attr('height', this._toScaledSize(img.height));
 
+                // If scaling factor is 1, we want to use CSS properties to fit the entire image onto the canvas
+                // by width.  
+                if (this.scalingFactor == 1) {
+                    cvs.attr('style', 'width: 100%' );
+                } else {
+                    cvs.attr('style', '' );
+                }
+
                 this._getContext().lineWidth = 1.0;
                 this._getContext().drawImage(img, 0, 0, img.width, img.height, 0, 0,
                     this._toScaledSize(img.width), this._toScaledSize(img.height));

--- a/web-app/src/resources/elements/image/image-canvas.js
+++ b/web-app/src/resources/elements/image/image-canvas.js
@@ -427,7 +427,6 @@ export class ImageCanvas {
             let img = new Image();
             img.onload = () => {
                 if( this.lastScalingFactor !== this.scalingFactor) {
-
                     this.lastScalingFactor = this.scalingFactor;
                 }
                 let cvs = this._getCanvas();
@@ -436,20 +435,14 @@ export class ImageCanvas {
                 cvs.attr('width', this._toScaledSize(img.width));
                 cvs.attr('height', this._toScaledSize(img.height));
 
-                // If scaling factor is 1, we want to use CSS properties to fit the entire image onto the canvas
-                // by width.  
-                if (this.scalingFactor == 1) {
-                    cvs.attr('style', 'width: 100%' );
-                } else {
-                    cvs.attr('style', '' );
-                }
-
                 this._getContext().lineWidth = 1.0;
                 this._getContext().drawImage(img, 0, 0, img.width, img.height, 0, 0,
                     this._toScaledSize(img.width), this._toScaledSize(img.height));
             }
             img.src = newImage;
             this._image = img;
+
+            alert("DEV 002: scaling factor in paint image = " + this.scalingFactor);
         } else {
             let canvas = this._getCanvas();
             let ctx = this._getContext();

--- a/web-app/src/resources/elements/panels/main-panel.html
+++ b/web-app/src/resources/elements/panels/main-panel.html
@@ -32,6 +32,7 @@
         <settings-panel if.bind="showSettings" options.bind="options"></settings-panel>
         <image-canvas class="${imagePanelClassnames}"
                       image.bind="dataURI"
+                      ref="imageCanvas"
                       bound-regions.bind="boundRegions"
                       selected-region.bind="selectedRegion"
                       scaling-factor.bind="scalingFactor"></image-canvas>

--- a/web-app/src/resources/elements/panels/main-panel.js
+++ b/web-app/src/resources/elements/panels/main-panel.js
@@ -287,10 +287,23 @@ export class MainPanel {
             let img = new Image();
             img.onload = () => {
                 if (this.options.image.fitImageToWindow) {
-                    if ( img.width > img.height) {
-                        this.scalingFactor = this.element.offsetWidth / img.width;
+
+                    let calculatedScalingFactor = 1;
+
+                    if ( (this.element.offsetWidth / img.width) < (this.element.offsetHeight / img.height)) {
+                        calculatedScalingFactor = this.element.offsetWidth / img.width;
                     } else {
-                        this.scalingFactor = this.element.offsetHeight / img.height;
+                        calculatedScalingFactor = this.element.offsetHeight / img.height;
+                    }
+
+                    if (calculatedScalingFactor < 0.25) {
+                        this.scalingFactor = 0.125;
+                    } else if (calculatedScalingFactor < 0.5) {
+                        this.scalingFactor = 0.25;
+                    } else if (calculatedScalingFactor < 1) {
+                        this.scalingFactor = 0.5;
+                    } else {
+                        this.scalingFactor = 1;
                     }
                 }
             }

--- a/web-app/src/resources/elements/panels/main-panel.js
+++ b/web-app/src/resources/elements/panels/main-panel.js
@@ -267,6 +267,10 @@ export class MainPanel {
     selectedFileChanged() {
         this.clear();
         if (this.selectedFile) {
+
+            // when we open up a new image, always open up with a scale factor of 1.
+            this.scalingFactor = 1;
+
             this.fileManager.asFile(this.selectedFile).then(f => {
                 this._processFile(f);
             });

--- a/web-app/src/resources/elements/panels/main-panel.js
+++ b/web-app/src/resources/elements/panels/main-panel.js
@@ -286,29 +286,42 @@ export class MainPanel {
         if (this.dataURI) {
             let img = new Image();
             img.onload = () => {
-                if (this.options.image.fitImageToWindow) {
-
-                    let calculatedScalingFactor = 1;
-
-                    if ( (this.element.offsetWidth / img.width) < (this.element.offsetHeight / img.height)) {
-                        calculatedScalingFactor = this.element.offsetWidth / img.width;
-                    } else {
-                        calculatedScalingFactor = this.element.offsetHeight / img.height;
-                    }
-
-                    if (calculatedScalingFactor < 0.25) {
-                        this.scalingFactor = 0.125;
-                    } else if (calculatedScalingFactor < 0.5) {
-                        this.scalingFactor = 0.25;
-                    } else if (calculatedScalingFactor < 1) {
-                        this.scalingFactor = 0.5;
-                    } else {
-                        this.scalingFactor = 1;
-                    }
+                if (_.get(this.options, 'image.fitImageToWindow', false) && this.imageCanvas) {
+                    this.scalingFactor = this.getScalingFactorFromImage(this.imageCanvas, img);
                 }
             }
             img.src = this.dataURI;
         }
+    }
+
+    /**
+     * Retrieve the closest scaling factor based on the image width or height relative to the
+     * canvas offsetWidth or offsetHeight.  The smaller ratio will be used for comparison.  The final scaling
+     * factor must match one of the predefined scaling factors or will be set to 1.0 (equivalent to 100% zoom)
+     *
+     * NOTE: This should be called after the image is loaded to ensure the dimensions are present
+     *
+     * @param elm   The on screen element to size to
+     * @param img   The image used for calculation of sizing
+     *
+     * @returns {number}
+     */
+    getScalingFactorFromImage(elm, img) {
+        let scaleFactor = 1.0;
+        if ((elm.offsetWidth / img.width) < (elm.offsetHeight / img.height)) {
+            scaleFactor = Math.min(elm.offsetWidth / img.width, 1.0);
+        } else {
+            scaleFactor = Math.min(elm.offsetHeight / img.height, 1.0);
+        }
+
+        if (scaleFactor < 0.25) {
+            scaleFactor = 0.125;
+        } else if (scaleFactor < 0.5) {
+            scaleFactor = 0.25;
+        } else if (scaleFactor < 1.0) {
+            scaleFactor = 0.5;
+        }
+        return scaleFactor;
     }
 
     /**

--- a/web-app/src/resources/elements/panels/main-panel.js
+++ b/web-app/src/resources/elements/panels/main-panel.js
@@ -267,14 +267,25 @@ export class MainPanel {
     selectedFileChanged() {
         this.clear();
         if (this.selectedFile) {
-
-            // when we open up a new image, always open up with a scale factor of 1.
-            this.scalingFactor = 1;
-
             this.fileManager.asFile(this.selectedFile).then(f => {
                 this._processFile(f);
             });
+        }
+    }
 
+    setScalingFactor() {
+        if (this.dataURI) {
+            let img = new Image();
+            img.onload = () => {
+                if (false) {
+                    if ( img.width > img.height) {
+                        this.scalingFactor = this.element.offsetWidth / img.width;
+                    } else {
+                        this.scalingFactor = this.element.offsetHeight / img.height;
+                    }
+                }
+            }
+            img.src = this.dataURI;
         }
     }
 
@@ -296,6 +307,7 @@ export class MainPanel {
             _.set(this.options, 'mimeType', mime);
             this.handler.readImage(file, false).then(dataURI => {
                 this.dataURI = dataURI;
+                this.setScalingFactor();
                 this.image = this.handler.toObjectUrl(dataURI, this.options);
                 this.processing = false;
                 this.eventAggregator.publish(EventNames.STATUS_MESSAGE, {

--- a/web-app/src/resources/elements/panels/main-panel.js
+++ b/web-app/src/resources/elements/panels/main-panel.js
@@ -273,11 +273,15 @@ export class MainPanel {
         }
     }
 
+    /**
+     * User has the option to open up image to fit screen or to use the last zoom setting.  This is determined
+     * by a global setting.
+     */
     setScalingFactor() {
         if (this.dataURI) {
             let img = new Image();
             img.onload = () => {
-                if (false) {
+                if (this.options.image.fitImageToWindow) {
                     if ( img.width > img.height) {
                         this.scalingFactor = this.element.offsetWidth / img.width;
                     } else {

--- a/web-app/src/resources/elements/panels/settings-panel.html
+++ b/web-app/src/resources/elements/panels/settings-panel.html
@@ -6,23 +6,26 @@
     <div class="panel container">
         <form>
             <fieldset>
-                <legend>${'titles.image-settings'|t}</legend>
-                <div class="container">
-                    <div class="form-group left-div">
-                        <label>${'labels.default-image-type'|t}</label>
-                        <select class="form-control" value.bind="settings.image.defaultType">
-                            <option repeat.for="imageType of imageTypes" model.bind="imageType">
-                                ${'labels.image.' + imageType|t}
-                            </option>
-                        </select>
-                    </div>
-                    <div class="form-check right-div">
+                <legend>${'titles.application-settings'|t}</legend>
+                <div class="form-group">
+                    <div class="form-check">
                         <input class="form-check-input"
                                type="checkbox"
                                name="fitImageToWindow"
                                checked.bind="settings.image.fitImageToWindow">
                         <label class="form-check-label">${'labels.fit-image-to-window'|t}</label>
                     </div>
+                </div>
+            </fieldset>
+            <fieldset>
+                <legend>${'titles.image-settings'|t}</legend>
+                <div class="form-group">
+                    <label>${'labels.default-image-type'|t}</label>
+                    <select class="form-control" value.bind="settings.image.defaultType">
+                        <option repeat.for="imageType of imageTypes" model.bind="imageType">
+                            ${'labels.image.' + imageType|t}
+                        </option>
+                    </select>
                 </div>
                 <div class="form-group">
                     <label>${'labels.dpi-default-usage'|t}</label>

--- a/web-app/src/resources/elements/panels/settings-panel.html
+++ b/web-app/src/resources/elements/panels/settings-panel.html
@@ -7,13 +7,22 @@
         <form>
             <fieldset>
                 <legend>${'titles.image-settings'|t}</legend>
-                <div class="form-group">
-                    <label>${'labels.default-image-type'|t}</label>
-                    <select class="form-control" value.bind="settings.image.defaultType">
-                        <option repeat.for="imageType of imageTypes" model.bind="imageType">
-                            ${'labels.image.' + imageType|t}
-                        </option>
-                    </select>
+                <div class="container">
+                    <div class="form-group left-div">
+                        <label>${'labels.default-image-type'|t}</label>
+                        <select class="form-control" value.bind="settings.image.defaultType">
+                            <option repeat.for="imageType of imageTypes" model.bind="imageType">
+                                ${'labels.image.' + imageType|t}
+                            </option>
+                        </select>
+                    </div>
+                    <div class="form-check right-div">
+                        <input class="form-check-input"
+                               type="checkbox"
+                               name="fitImageToWindow"
+                               checked.bind="settings.image.fitImageToWindow">
+                        <label class="form-check-label">${'labels.fit-image-to-window'|t}</label>
+                    </div>
                 </div>
                 <div class="form-group">
                     <label>${'labels.dpi-default-usage'|t}</label>

--- a/web-app/src/resources/elements/panels/settings-panel.scss
+++ b/web-app/src/resources/elements/panels/settings-panel.scss
@@ -6,6 +6,10 @@ settings-panel {
     height:         100%;
     margin-top:     $margin-med;
 
+    fieldset {
+        padding: $padding-med $padding-x-thick;
+    }
+
     .form-control {
         font-size: 1.1rem;
     }
@@ -24,18 +28,6 @@ settings-panel {
 
     .custom-radio {
         padding-left: 3rem;
-    }
-
-    .left-div {
-        width: 40%;
-        float: left;
-    }
-
-    .right-div {
-        width: 60%;
-        float:right;
-        text-align: right;
-        padding: 20px 0;
     }
 
     .range-slider {

--- a/web-app/src/resources/elements/panels/settings-panel.scss
+++ b/web-app/src/resources/elements/panels/settings-panel.scss
@@ -26,6 +26,18 @@ settings-panel {
         padding-left: 3rem;
     }
 
+    .left-div {
+        width: 40%;
+        float: left;
+    }
+
+    .right-div {
+        width: 60%;
+        float:right;
+        text-align: right;
+        padding: 20px 0;
+    }
+
     .range-slider {
         display:        flex;
         flex-direction: row;

--- a/web-app/src/util/constants.js
+++ b/web-app/src/util/constants.js
@@ -19,7 +19,8 @@ export const TIFFCompression = ['lzw', 'jpeg', 'deflate'];
 
 export const DefaultOptions = {
     image:       {
-        defaultType: ImageTypes[1]
+        defaultType:        ImageTypes[1],
+        fitImageToWindow:   false
     },
     dpi:         {
         mode:       'image',

--- a/web-app/test/unit/resources/elements/panels/main-panel-spec.js
+++ b/web-app/test/unit/resources/elements/panels/main-panel-spec.js
@@ -111,4 +111,37 @@ describe('MainPanel', () => {
             expect(mainpanel.folders[2]).toStrictEqual(folders[1]);
         });
     });
+
+    describe('setScalingFactor', () => {
+
+        beforeEach(() => {
+            // need to mock the config setting: this.options.image.fitImageToWindow
+            mainpanel.offsetWidth = 100;
+            mainpanel.offsetHeight = 100;
+        });
+
+        it('verify minimum zoom of 0.125', async () => {
+            // mock image dimension
+            mainpanel.setScalingFactor();
+            expect(mainpanel.scalingFactor).toBe(0.125);
+        });
+
+        it('verify maximum zoom of 1', async () => {
+            // mock image dimension
+            mainpanel.setScalingFactor();
+            expect(mainpanel.scalingFactor).toBe(1);
+        });
+
+        it('verify zoom to fit wide image', async () => {
+            // mock image dimension
+            mainpanel.setScalingFactor();
+            expect(mainpanel.scalingFactor).toBe(0.25);
+        });
+
+        it('verify zoom to fit tall image', async () => {
+            // mock image dimension
+            mainpanel.setScalingFactor();
+            expect(mainpanel.scalingFactor).toBe(0.5);
+        });
+    });
 });

--- a/web-app/test/unit/resources/elements/panels/main-panel-spec.js
+++ b/web-app/test/unit/resources/elements/panels/main-panel-spec.js
@@ -114,34 +114,80 @@ describe('MainPanel', () => {
 
     describe('setScalingFactor', () => {
 
+        const dataUri = 'data:image/jpeg;base64,R0lGODlhkAGQAfcAAAQCBJKDLJSSlExGHNS/NNTOtFRSVCckFGxjJPjgXMzKzHyCfKuqpDMxNPzu0fXaJGxqZLikLEdCPBQSDDQyFOvq7H90LL6PlFxOw==';
+
+        const mockImage = {
+            src: null,
+            onload: () => {}
+        };
+
+        const realImage = global.Image;
+
+        beforeAll(() => {
+            global.Image = () => { return mockImage; };
+        });
+
+        afterAll(() => {
+            global.Image = realImage;
+        })
+
         beforeEach(() => {
-            // need to mock the config setting: this.options.image.fitImageToWindow
-            mainpanel.offsetWidth = 100;
-            mainpanel.offsetHeight = 100;
+            mainpanel.scalingFactor = 2.0; // dummy factor
+            mainpanel.options = {};
+            mainpanel.dataURI = dataUri;
         });
 
-        it('verify minimum zoom of 0.125', async () => {
-            // mock image dimension
+        it('verify no scaling calculation without option set', () => {
             mainpanel.setScalingFactor();
-            expect(mainpanel.scalingFactor).toBe(0.125);
+            mockImage.onload();
+            expect(mainpanel.scalingFactor).toBeCloseTo(2.0, 2);
         });
 
-        it('verify maximum zoom of 1', async () => {
-            // mock image dimension
+        it('scaling calculation run on image load with option set', () => {
+            mainpanel.imageCanvas = {offsetWidth: 400, offsetHeight: 400}; // current onscreen canvas size
+            _.set(mainpanel.options, 'image.fitImageToWindow', true);
+            mockImage.width = 700; // less than twice the size of the canvas
+            mockImage.height = 200;
             mainpanel.setScalingFactor();
-            expect(mainpanel.scalingFactor).toBe(1);
+            mockImage.onload(); // we need to ensure onload is called since src is not really triggering it
+
+            expect(mainpanel.scalingFactor).toBeCloseTo(0.5, 2);
         });
 
-        it('verify zoom to fit wide image', async () => {
-            // mock image dimension
-            mainpanel.setScalingFactor();
-            expect(mainpanel.scalingFactor).toBe(0.25);
+    });
+
+    describe('getScalingFactorFromImage', () => {
+
+        let elem = {};
+
+        beforeEach(() => {
+            elem.offsetWidth = 1024;
+            elem.offsetHeight = 1024;
         });
 
-        it('verify zoom to fit tall image', async () => {
-            // mock image dimension
-            mainpanel.setScalingFactor();
-            expect(mainpanel.scalingFactor).toBe(0.5);
+        it('verify minimum zoom of 0.125', () => {
+            // more than 8x the width
+            let image = {height: 2048, width: 8600};
+            let factor = mainpanel.getScalingFactorFromImage(elem, image);
+            expect(factor).toBeCloseTo(0.125, 4);
+        });
+
+        it('verify maximum zoom of 1', () => {
+            let image = {height: 600, width: 800};
+            let factor = mainpanel.getScalingFactorFromImage(elem, image);
+            expect(factor).toBeCloseTo(1.0, 4);
+        });
+
+        it('verify zoom to fit wide image', () => {
+            let image = {height: 1500, width: 4080};
+            let factor = mainpanel.getScalingFactorFromImage(elem, image);
+            expect(factor).toBeCloseTo(0.25, 4);
+        });
+
+        it('verify zoom to fit tall image', () => {
+            let image = {height: 2040, width: 1000};
+            let factor = mainpanel.getScalingFactorFromImage(elem, image);
+            expect(factor).toBeCloseTo(0.5, 4);
         });
     });
 });


### PR DESCRIPTION
When new image is opened, it will use the last scaling factor.  I don't think this is ideal.

This is not a perfect solution.  When the image is fit to the screen width, the scale factor can be quite different from 1.  This will make the zoom action "jumpy".